### PR TITLE
v2.6.2 - Fixes for #41 and bring Resource and Property functions up-to-spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ launch.json
 vaporshell-snippets**
 TestResults**.xml
 BuildOutput/*
+VaporShell.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- TOC -->
 
+* [2.6.2](#262)
 * [2.6.1](#261)
 * [2.6.0](#260)
 * [2.5.5](#255)
@@ -37,6 +38,13 @@
 * [0.7.02](#0702)
 
 <!-- /TOC -->
+
+## 2.6.2
+
+* [Issue #41](https://github.com/scrthq/VaporShell/issues/41)
+  * Fixed: `Update-VSStack` and `Update-VSStackSet` were removing the `BuiltWith = VaporShell` tags if not explicitly included when updating Tags.
+* Miscellaneous
+  * Brought Resource Type and Property Type functions up to current spec sheet.
 
 ## 2.6.1
 

--- a/VaporShell/Public/SDK Wrappers/CloudFormation/Update-VSStack.ps1
+++ b/VaporShell/Public/SDK Wrappers/CloudFormation/Update-VSStack.ps1
@@ -127,6 +127,7 @@ function Update-VSStack {
                 }
                 Tags {
                     $tagList = New-Object 'System.Collections.Generic.List[Amazon.CloudFormation.Model.Tag]'
+                    $tagList.Add((VSStackTag -Key BuiltWith -Value VaporShell))
                     if ($null -ne $Tags) {
                         foreach ($key in $Tags.Keys) {
                             $tagList.Add((VSStackTag -Key $key -Value $Tags[$key]))

--- a/VaporShell/Public/SDK Wrappers/CloudFormation/Update-VSStackSet.ps1
+++ b/VaporShell/Public/SDK Wrappers/CloudFormation/Update-VSStackSet.ps1
@@ -103,6 +103,7 @@ function Update-VSStackSet {
                 }
                 Tags {
                     $tagList = New-Object 'System.Collections.Generic.List[Amazon.CloudFormation.Model.Tag]'
+                    $tagList.Add((VSStackTag -Key BuiltWith -Value VaporShell))
                     if ($null -ne $Tags) {
                         foreach ($key in $Tags.Keys) {
                             $tagList.Add((VSStackTag -Key $key -Value $Tags[$key]))

--- a/VaporShell/VaporShell.psd1
+++ b/VaporShell/VaporShell.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'VaporShell.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '2.6.1'
+    ModuleVersion          = '2.6.2'
 
     # ID used to uniquely identify this module
     GUID                   = 'd526494c-6e59-41ff-ad05-eedbc1473b6a'
@@ -105,7 +105,7 @@ Website: https://vaporshell.io/
         PSData = @{
 
             # Tags applied to this module. These help with module discovery in online galleries.
-            Tags       = 'AWS','CloudFormation','CFN','JSON','YAML','PSEdition_Core','PSEdition_Desktop'
+            Tags       = 'AWS','CloudFormation','CFN','JSON','YAML','IaC','InfrastructureAsCode','PSEdition_Core','PSEdition_Desktop'
 
             # A URL to the license for this module.
             LicenseUri = 'https://github.com/scrthq/VaporShell/blob/master/LICENSE'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,9 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: . ./build.ps1 -Task PesterOnly
+  - powershell: |
+      $env:Coveralls = '$(Coveralls)'
+      . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -70,7 +72,9 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: . ./build.ps1 -Task PesterOnly
+  - powershell: |
+      $env:Coveralls = '$(Coveralls)'
+      . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -96,7 +100,9 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: . ./build.ps1 -Task PesterOnly
+  - powershell: |
+      $env:Coveralls = '$(Coveralls)'
+      . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -126,6 +132,7 @@ phases:
       downloadPath: '$(Build.SourcesDirectory)'
 
   - powershell: |
+      $env:Coveralls = '$(Coveralls)'
       $Env:Path = [Environment]::GetEnvironmentVariable('Path',[EnvironmentVariableTarget]::Machine)
       pwsh -command ". ./build.ps1 -Task PesterOnly"
     displayName: Test Module

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,9 +44,7 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: |
-      $env:Coveralls = '$(Coveralls)'
-      . ./build.ps1 -Task PesterOnly
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,13 @@ phases:
     name: Hosted VS2017
 
   steps:
-  - powershell: . ./build.ps1 -Task Pester
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: BuildOutput
+      downloadPath: '$(Build.SourcesDirectory)'
+
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -58,7 +64,13 @@ phases:
     name: Hosted Ubuntu 1604
 
   steps:
-  - powershell: . ./build.ps1 -Task Pester
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: BuildOutput
+      downloadPath: '$(Build.SourcesDirectory)'
+
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -78,7 +90,13 @@ phases:
     name: Hosted macOS
 
   steps:
-  - powershell: . ./build.ps1 -Task Pester
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: BuildOutput
+      downloadPath: '$(Build.SourcesDirectory)'
+
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -101,9 +119,15 @@ phases:
   - script: 'choco install powershell-core --yes'
     displayName: 'Install Powershell v6'
 
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: BuildOutput
+      downloadPath: '$(Build.SourcesDirectory)'
+
   - powershell: |
       $Env:Path = [Environment]::GetEnvironmentVariable('Path',[EnvironmentVariableTarget]::Machine)
-      pwsh -command ". ./build.ps1 -Task Pester"
+      pwsh -command ". ./build.ps1 -Task PesterOnly"
     displayName: Test Module
 
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -128,6 +128,12 @@ phases:
   steps:
   - powershell: |
       $env:SourceBranch = '$(Build.SourceBranch)'
-      $env:NuGetApiKey = '$(NuGetApiKey)'
+      $env:Coveralls = '$(Coveralls)'
+      $Env:GitHubPAT = '$(GitHub.PAT)'
+      $Env:NuGetApiKey = '$(NuGetApiKey)'
+      $Env:TwitterAccessSecret = '$(Twitter.AccessSecret)'
+      $Env:TwitterAccessToken = '$(Twitter.AccessToken)'
+      $Env:TwitterConsumerKey = '$(Twitter.ConsumerKey)'
+      $Env:TwitterConsumerSecret = '$(Twitter.ConsumerSecret)'
       . ./build.ps1 -Task Deploy
     displayName: Deploy to PowerShell Gallery

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@ phases:
     name: Hosted VS2017
 
   steps:
-  - powershell: . ./build.ps1 -Task Init,Clean,Compile
+  - powershell: . ./build.ps1
     displayName: Compile Module
 
   - task: PublishBuildArtifacts@1
@@ -38,7 +38,7 @@ phases:
     name: Hosted VS2017
 
   steps:
-  - powershell: . ./build.ps1
+  - powershell: . ./build.ps1 -Task Pester
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -58,7 +58,7 @@ phases:
     name: Hosted Ubuntu 1604
 
   steps:
-  - powershell: . ./build.ps1
+  - powershell: . ./build.ps1 -Task Pester
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -78,7 +78,7 @@ phases:
     name: Hosted macOS
 
   steps:
-  - powershell: . ./build.ps1
+  - powershell: . ./build.ps1 -Task Pester
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -103,7 +103,7 @@ phases:
 
   - powershell: |
       $Env:Path = [Environment]::GetEnvironmentVariable('Path',[EnvironmentVariableTarget]::Machine)
-      pwsh -command ". ./build.ps1"
+      pwsh -command ". ./build.ps1 -Task Pester"
     displayName: Test Module
 
   - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -150,9 +150,13 @@ phases:
     name: Hosted VS2017
 
   steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download Build Artifacts'
+    inputs:
+      artifactName: BuildOutput
+      downloadPath: '$(Build.SourcesDirectory)'
+
   - powershell: |
-      $env:SourceBranch = '$(Build.SourceBranch)'
-      $env:Coveralls = '$(Coveralls)'
       $Env:GitHubPAT = '$(GitHub.PAT)'
       $Env:NuGetApiKey = '$(NuGetApiKey)'
       $Env:TwitterAccessSecret = '$(Twitter.AccessSecret)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,9 +72,7 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: |
-      $env:Coveralls = '$(Coveralls)'
-      . ./build.ps1 -Task PesterOnly
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -100,9 +98,7 @@ phases:
       artifactName: BuildOutput
       downloadPath: '$(Build.SourcesDirectory)'
 
-  - powershell: |
-      $env:Coveralls = '$(Coveralls)'
-      . ./build.ps1 -Task PesterOnly
+  - powershell: . ./build.ps1 -Task PesterOnly
     displayName: Test Module
 
   - task: PublishTestResults@2
@@ -132,7 +128,6 @@ phases:
       downloadPath: '$(Build.SourcesDirectory)'
 
   - powershell: |
-      $env:Coveralls = '$(Coveralls)'
       $Env:Path = [Environment]::GetEnvironmentVariable('Path',[EnvironmentVariableTarget]::Machine)
       pwsh -command ". ./build.ps1 -Task PesterOnly"
     displayName: Test Module

--- a/psake.ps1
+++ b/psake.ps1
@@ -246,9 +246,9 @@ $pesterScriptBlock = {
                 }
             }
         }
-        # Commented out due to extra time this takes when running against the compiled module
         '    Including CodeCoverage report'
-        $pesterParams['CodeCoverage'] = $coveredFunctions
+        # Commented out due to extra time this takes when running against the compiled module
+        ### $pesterParams['CodeCoverage'] = $coveredFunctions
     }
     if ($global:ExcludeTag) {
         $pesterParams['ExcludeTag'] = $global:ExcludeTag

--- a/psake.ps1
+++ b/psake.ps1
@@ -249,6 +249,7 @@ $pesterScriptBlock = {
         '    Including CodeCoverage report'
         # Commented out due to extra time this takes when running against the compiled module
         ### $pesterParams['CodeCoverage'] = $coveredFunctions
+        $pesterParams['CodeCoverage'] = (Join-Path $outputModVerDir "$($env:BHProjectName).psm1")
     }
     if ($global:ExcludeTag) {
         $pesterParams['ExcludeTag'] = $global:ExcludeTag

--- a/psake.ps1
+++ b/psake.ps1
@@ -427,7 +427,7 @@ Task Deploy -Depends Init {
     Import-Module $($env:BHProjectName)
 
     # Otherwise, provide the path to the manifest:
-    Import-Module -Path C:\$($env:BHProjectName)\$($versionToDeploy.ToString())\$($env:BHProjectName).psd1
+    Import-Module -Path C:\MyPSModules\$($env:BHProjectName)\$($versionToDeploy.ToString())\$($env:BHProjectName).psd1
     ``````
 "@
                     $gitHubParams = @{

--- a/psake.ps1
+++ b/psake.ps1
@@ -247,6 +247,7 @@ $pesterScriptBlock = {
             }
         }
         # Commented out due to extra time this takes when running against the compiled module
+        '    Including CodeCoverage report'
         $pesterParams['CodeCoverage'] = $coveredFunctions
     }
     if ($global:ExcludeTag) {
@@ -272,9 +273,9 @@ $pesterScriptBlock = {
     $env:PSModulePath = $origModulePath
 }
 
-task Pester -Depends Compile $pesterScriptBlock -description 'Run Pester tests'
+task Pester -Depends Import $pesterScriptBlock -description 'Run Pester tests'
 
-task PesterOnly -Depends Init $pesterScriptBlock -description 'Run Pester tests only (no Clean/Compile)'
+task PesterOnly -Depends Update $pesterScriptBlock -description 'Run Pester tests only (no Clean/Compile)'
 
 task Analyze -Depends Pester {
     $analysis = Invoke-ScriptAnalyzer -Path "$PSScriptRoot\$($env:BHProjectName)" -Recurse -Verbose:$false

--- a/psake.ps1
+++ b/psake.ps1
@@ -198,6 +198,11 @@ Export-ModuleMember -Function (Get-Command -Module VaporShell.DSL).Name -Variabl
     Get-ChildItem $outputModVerDir | Format-Table -Autosize
 } -description 'Compiles module from source'
 
+Task Import -Depends Compile {
+    '    Testing import of compiled module'
+    Import-Module (Join-Path $outputModVerDir "$($env:BHProjectName).psd1")
+} -description 'Imports the newly compiled module'
+
 $pesterScriptBlock = {
     "    Getting correctly cased FullName for $outputModDir..."
     $outputModDir = (Get-ChildItem (Split-Path $outputModDir -Parent) -Directory | Where-Object {$_.Name -eq (Get-Item $outputModDir).Name}).FullName
@@ -224,8 +229,14 @@ $pesterScriptBlock = {
     Remove-Module $ENV:BHProjectName -ErrorAction SilentlyContinue -Verbose:$false
     Import-Module -Name $outputModDir -Force -Verbose:$false
     $testResultsXml = Join-Path -Path $outputDir -ChildPath $TestFile
-    $coverage = @{}
-    if ($PSVersionTable.PSVersion.Major -lt 6) {
+    $pesterParams = @{
+        OutputFormat = 'NUnitXml'
+        OutputFile   = $testResultsXml
+        PassThru     = $true
+        Path         = $tests
+    }
+    if ($ENV:BHBuildSystem -eq 'VSTS' -and $PSVersionTable.PSVersion.Major -lt 6 -and $null -ne $env:Coveralls) {
+        '    Building list of functions to include for Code Coverage...'
         $coveredFunctions = @()
         "$($env:BHPSModulePath)\Public\Condition Functions\*","$($env:BHPSModulePath)\Public\Intrinsic Functions\*","$($env:BHPSModulePath)\Public\Primary Functions\*","$($env:BHPSModulePath)\Public\Transform\*","$($env:BHPSModulePath)\Public\*-Vaporshell.ps1" | Foreach-Object {
             foreach ($item in (Get-Item $_)) {
@@ -236,17 +247,23 @@ $pesterScriptBlock = {
             }
         }
         # Commented out due to extra time this takes when running against the compiled module
-        # $coverage['CodeCoverage'] = $coveredFunctions
+        $pesterParams['CodeCoverage'] = $coveredFunctions
     }
-    '    Invoking Pester...'
-    $testResults = Invoke-Pester -Path $tests -PassThru -OutputFile $testResultsXml -OutputFormat NUnitXml #@coverage
+    if ($global:ExcludeTag) {
+        $pesterParams['ExcludeTag'] = $global:ExcludeTag
+        "    Invoking Pester and excluding tag(s) [$($global:ExcludeTag -join ', ')]..."
+    }
+    else {
+        '    Invoking Pester...'
+    }
+    $testResults = Invoke-Pester @pesterParams
     '    Pester invocation complete!'
-    if ($PSVersionTable.PSVersion.Major -lt 6 -and $null -ne $env:Coveralls -and $coverage.Keys -contains 'CodeCoverage') {
-        '    Uploading Code Coverage to Coveralls...'
-        $coverage = Format-Coverage -PesterResults $TestResults -CoverallsApiToken $env:Coveralls -BranchName $ENV:APPVEYOR_REPO_BRANCH -Verbose
+    if ($ENV:BHBuildSystem -eq 'VSTS' -and $PSVersionTable.PSVersion.Major -lt 6 -and $null -ne $env:Coveralls -and $pesterParams.Keys -contains 'CodeCoverage') {
+        '    Formatting test results into a Coveralls coverage report...'
+        $coverage = Format-Coverage -PesterResults $TestResults -CoverallsApiToken $env:Coveralls -BranchName $env:BHBranchName -Verbose
+        '    Uploading coverage report to Coveralls...'
         Publish-Coverage -Coverage $coverage -Verbose
     }
-
     if ($testResults.FailedCount -gt 0) {
         $testResults | Format-List
         Write-Error -Message 'One or more Pester tests failed. Build cannot continue!'
@@ -279,8 +296,88 @@ task Analyze -Depends Pester {
     }
 } -description 'Run PSScriptAnalyzer'
 
-Task Deploy -Depends Compile {
-    if ($env:BHBuildSystem -eq 'VSTS' -and $env:BHCommitMessage -match '!deploy' -and $env:BHBranchName -eq "master") {
+Task Deploy -Depends Import {
+    function Publish-GitHubRelease {
+        <#
+            .SYNOPSIS
+            Publishes a release to GitHub Releases. Borrowed from https://www.herebedragons.io/powershell-create-github-release-with-artifact
+        #>
+        [CmdletBinding()]
+        Param (
+            [parameter(Mandatory = $true)]
+            [String]
+            $VersionNumber,
+            [parameter(Mandatory = $false)]
+            [String]
+            $CommitId = 'master',
+            [parameter(Mandatory = $true)]
+            [String]
+            $ReleaseNotes,
+            [parameter(Mandatory = $true)]
+            [ValidateScript( {Test-Path $_})]
+            [String]
+            $ArtifactPath,
+            [parameter(Mandatory = $true)]
+            [String]
+            $GitHubUsername,
+            [parameter(Mandatory = $true)]
+            [String]
+            $GitHubRepository,
+            [parameter(Mandatory = $true)]
+            [String]
+            $GitHubApiKey,
+            [parameter(Mandatory = $false)]
+            [Switch]
+            $PreRelease,
+            [parameter(Mandatory = $false)]
+            [Switch]
+            $Draft
+        )
+        $releaseData = @{
+            tag_name         = [string]::Format("v{0}", $VersionNumber)
+            target_commitish = $CommitId
+            name             = [string]::Format("$($env:BHProjectName) v{0}", $VersionNumber)
+            body             = $ReleaseNotes
+            draft            = [bool]$Draft
+            prerelease       = [bool]$PreRelease
+        }
+
+        $auth = 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes($gitHubApiKey + ":x-oauth-basic"))
+
+        $releaseParams = @{
+            Uri         = "https://api.github.com/repos/$GitHubUsername/$GitHubRepository/releases"
+            Method      = 'POST'
+            Headers     = @{
+                Authorization = $auth
+            }
+            ContentType = 'application/json'
+            Body        = (ConvertTo-Json $releaseData -Compress)
+        }
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        $result = Invoke-RestMethod @releaseParams
+        $uploadUri = $result | Select-Object -ExpandProperty upload_url
+        $uploadUri = $uploadUri -creplace '\{\?name,label\}'
+        $artifact = Get-Item $ArtifactPath
+        $uploadUri = $uploadUri + "?name=$($artifact.Name)"
+        $uploadFile = $artifact.FullName
+
+        $uploadParams = @{
+            Uri         = $uploadUri
+            Method      = 'POST'
+            Headers     = @{
+                Authorization = $auth
+            }
+            ContentType = 'application/zip'
+            InFile      = $uploadFile
+        }
+        $result = Invoke-RestMethod @uploadParams
+    }
+    if (($env:BHBuildSystem -eq 'VSTS' -and $env:BHCommitMessage -match '!deploy' -and $env:BHBranchName -eq "master") -or $global:ForceDeploy -eq $true) {
+        if ($null -eq (Get-Module PoshTwit -ListAvailable)) {
+            "    Installing PoshTwit module..."
+            Install-Module PoshTwit -Scope CurrentUser
+        }
+        Import-Module PoshTwit -Verbose:$false
         # Load the module, read the exported functions, update the psd1 FunctionsToExport
         $commParsed = $env:BHCommitMessage | Select-String -Pattern '\sv\d\.\d\.\d\s'
         if ($commParsed) {
@@ -322,9 +419,83 @@ Task Deploy -Depends Compile {
         }
         # Bump the module version
         if ($versionToDeploy) {
-            Update-Metadata -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1") -PropertyName ModuleVersion -Value $versionToDeploy
-            "    Publishing version [$($versionToDeploy)] to PSGallery..."
-            Publish-Module -Path $outputModVerDir -NuGetApiKey $env:NugetApiKey -Repository PSGallery
+            try {
+                if ($ENV:BHBuildSystem -eq 'VSTS' -and -not [String]::IsNullOrEmpty($env:NugetApiKey)) {
+                    "    Publishing version [$($versionToDeploy)] to PSGallery..."
+                    Update-Metadata -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1") -PropertyName ModuleVersion -Value $versionToDeploy
+                    Publish-Module -Path $outputModVerDir -NuGetApiKey $env:NugetApiKey -Repository PSGallery
+                    "    Deployment successful!"
+                }
+                else {
+                    "    [SKIPPED] Deployment of version [$($versionToDeploy)] to PSGallery"
+                }
+                $commitId = git rev-parse --verify HEAD
+                if (-not [String]::IsNullOrEmpty($env:GitHubPAT)) {
+                    "    Creating Release ZIP..."
+                    $zipPath = [System.IO.Path]::Combine($PSScriptRoot,"$($env:BHProjectName).zip")
+                    if (Test-Path $zipPath) {
+                        Remove-Item $zipPath -Force
+                    }
+                    Add-Type -Assembly System.IO.Compression.FileSystem
+                    [System.IO.Compression.ZipFile]::CreateFromDirectory($outputModDir,$zipPath)
+                    "    Publishing Release v$($versionToDeploy) @ commit Id [$($commitId)] to GitHub..."
+                    $ReleaseNotes = "# Changelog`n`n"
+                    $ReleaseNotes += (git log -1 --pretty=%B | Select-Object -Skip 2) -join "`n"
+                    $ReleaseNotes += "`n`n***`n`n# Instructions`n`n"
+                    $ReleaseNotes += @"
+1. [Click here](https://github.com/scrthq/$($env:BHProjectName)/releases/download/v$($versionToDeploy.ToString())/$($env:BHProjectName).zip) to download the *$($env:BHProjectName).zip* file attached to the release.
+2. **If on Windows**: Right-click the downloaded zip, select Properties, then unblock the file.
+    > _This is to prevent having to unblock each file individually after unzipping._
+3. Unzip the archive.
+4. (Optional) Place the module folder somewhere in your ``PSModulePath``.
+    > _You can view the paths listed by running the environment variable ```$env:PSModulePath``_
+5. Import the module, using the full path to the PSD1 file in place of ``$($env:BHProjectName)`` if the unzipped module folder is not in your ``PSModulePath``:
+    ``````powershell
+    # In `$env:PSModulePath
+    Import-Module $($env:BHProjectName)
+
+    # Otherwise, provide the path to the manifest:
+    Import-Module -Path C:\$($env:BHProjectName)\$($versionToDeploy.ToString())\$($env:BHProjectName).psd1
+    ``````
+"@
+                    $gitHubParams = @{
+                        VersionNumber    = $versionToDeploy.ToString()
+                        CommitId         = $commitId
+                        ReleaseNotes     = $ReleaseNotes
+                        ArtifactPath     = $zipPath
+                        GitHubUsername   = 'scrthq'
+                        GitHubRepository = $env:BHProjectName
+                        GitHubApiKey     = $env:GitHubPAT
+                        Draft            = $false
+                    }
+                    Publish-GitHubRelease @gitHubParams
+                    "    Release creation successful!"
+                }
+                else {
+                    "    [SKIPPED] Publishing Release v$($versionToDeploy) @ commit Id [$($commitId)] to GitHub"
+                }
+                if ($ENV:BHBuildSystem -eq 'VSTS' -and -not [String]::IsNullOrEmpty($env:TwitterAccessSecret) -and -not [String]::IsNullOrEmpty($env:TwitterAccessToken) -and -not [String]::IsNullOrEmpty($env:TwitterConsumerKey) -and -not [String]::IsNullOrEmpty($env:TwitterConsumerSecret)) {
+                    "    Publishing tweet about new release..."
+                    $manifest = Import-PowerShellDataFile -Path (Join-Path $outputModVerDir "$($env:BHProjectName).psd1")
+                    $text = "$($env:BHProjectName) v$($versionToDeploy) is now available on the #PSGallery! https://www.powershellgallery.com/packages/$($env:BHProjectName) #PowerShell"
+                    $manifest.PrivateData.PSData.Tags | Foreach-Object {
+                        $text += " #$($_)"
+                    }
+                    if ($text.Length -gt 280) {
+                        "    Trimming [$($text.Length - 280)] extra characters from tweet text to get to 280 character limit..."
+                        $text = $text.Substring(0,280)
+                    }
+                    "    Tweet text: $text"
+                    Publish-Tweet -Tweet $text -ConsumerKey $env:TwitterConsumerKey -ConsumerSecret $env:TwitterConsumerSecret -AccessToken $env:TwitterAccessToken -AccessSecret $env:TwitterAccessSecret
+                    "    Tweet successful!"
+                }
+                else {
+                    "    [SKIPPED] Twitter update of new release"
+                }
+            }
+            catch {
+                Write-Error $_ -ErrorAction Stop
+            }
         }
         else {
             Write-Host -ForegroundColor Yellow "No module version matched! Negating deployment to prevent errors"
@@ -335,4 +506,6 @@ Task Deploy -Depends Compile {
     else {
         Write-Host -ForegroundColor Magenta "Build system is not VSTS, commit message does not contain '!deploy' and/or branch is not 'master' -- skipping module update!"
     }
-} -description 'Deploy module to PSGallery'
+} -description 'Deploy module to PSGallery' -preaction {
+    Import-Module -Name $outputModDir -Force -Verbose:$false
+}

--- a/psake.ps1
+++ b/psake.ps1
@@ -33,14 +33,7 @@ task Init {
     Set-Location $ProjectRoot
     "Build System Details:"
     Get-Item ENV:BH*
-    if ($env:APPVEYOR) {
-        Get-Item ENV:APPVEYOR*
-    }
-    "`n"
-
-    "    Installing the latest version of Pester"
-    Install-Module -Name Pester -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Confirm:$false -ErrorAction Stop -Force -Verbose:$false
-    Import-Module -Name Pester -Verbose:$false -Force
+    Get-Item ENV:BUILD*
     if ($env:BHProjectName -cne $moduleName) {
         $env:BHProjectName = $moduleName
     }
@@ -196,6 +189,9 @@ Task Import -Depends Compile {
 } -description 'Imports the newly compiled module'
 
 $pesterScriptBlock = {
+    "    Installing the latest version of Pester"
+    Install-Module -Name Pester -Repository PSGallery -Scope CurrentUser -AllowClobber -SkipPublisherCheck -Confirm:$false -ErrorAction Stop -Force -Verbose:$false
+    Import-Module -Name Pester -Verbose:$false -Force
     "    Getting correctly cased FullName for $outputModDir..."
     $outputModDir = (Get-ChildItem (Split-Path $outputModDir -Parent) -Directory | Where-Object {$_.Name -eq (Get-Item $outputModDir).Name}).FullName
     "    FullName resolved to $outputModDir..."


### PR DESCRIPTION
## 2.6.2

* [Issue #41](https://github.com/scrthq/VaporShell/issues/41)
  * Fixed: `Update-VSStack` and `Update-VSStackSet` were removing the `BuiltWith = VaporShell` tags if not explicitly included when updating Tags.
* Miscellaneous
  * Brought Resource Type and Property Type functions up to current spec sheet.