### PR TITLE
!deploy v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- TOC -->
 
+* [2.8.1 - 2019-08-24](#281---2019-08-24)
 * [2.8.0 - 2019-08-08](#280---2019-08-08)
 * [2.7.3 - 2019-04-16](#273---2019-04-16)
 * [2.7.2 - 2019-04-16](#272---2019-04-16)
@@ -44,6 +45,12 @@
 * [0.7.02](#0702)
 
 <!-- /TOC -->
+
+## 2.8.1 - 2019-08-24
+
+* Miscellaneous
+  * Updated Package name casing on the PowerShell Gallery from `Vaporshell` to `VaporShell` to fix module importing on Linux.
+  * Brought Resource Type and Property Type functions up to current spec sheet.
 
 ## 2.8.0 - 2019-08-08
 

--- a/VaporShell/VaporShell.psd1
+++ b/VaporShell/VaporShell.psd1
@@ -12,7 +12,7 @@
     RootModule             = 'VaporShell.psm1'
 
     # Version number of this module.
-    ModuleVersion          = '2.8.0'
+    ModuleVersion          = '2.8.1'
 
     # ID used to uniquely identify this module
     GUID                   = 'd526494c-6e59-41ff-ad05-eedbc1473b6a'


### PR DESCRIPTION
## 2.8.1 - 2019-08-24

* Miscellaneous
  * Updated Package name casing on the PowerShell Gallery from `Vaporshell` to `VaporShell` to fix module importing on Linux.
  * Brought Resource Type and Property Type functions up to current spec sheet.