### PR TITLE
docs: add example for SSM resource datasync across multiple accounts

### DIFF
--- a/Examples/SSM Resource Datasync - Multiple Accounts.ps1
+++ b/Examples/SSM Resource Datasync - Multiple Accounts.ps1
@@ -1,0 +1,47 @@
+Import-Module Nameit, Vaporshell
+$BuildRoot = $PSScriptRoot
+
+# Assume this was created in a different step
+$S3Destination = 'Foobar'
+$BucketRegion = 'eu-west-1'
+$ExportPath =  Join-Path $BuildRoot 'cloudformation'
+New-Item -Path $ExportPath -ItemType Directory -Force | Out-Null
+$template = Initialize-Vaporshell -Description 'Resource datasync for SSM'
+
+$AWSProfilesList = @('my-cred-name')
+foreach ($AWSProfileName in $AWSProfilesList)
+{
+    Set-VSCredential -ProfileName $AWSProfileName
+    $ProfileExportPath =  Join-Path $ExportPath $AWSProfileName
+    New-Item -Path $ProfileExportPath -ItemType Directory -Force | Out-Null
+
+    $IncludeRegions = @(
+        # 'eu-central-1',
+        'eu-west-1'
+        # 'eu-west-2',
+        # 'eu-west-3',
+        # 'us-east-1',
+        # 'us-east-2',
+        # 'us-west-1',
+        # 'us-west-2'
+    )
+    foreach ($region in $IncludeRegions)
+    {
+        $ExportTemplate = Join-Path $ProfileExportPath "datasync-$region.yml"
+        $StackName = "ssm-resource-data-sync-$region"
+        $SplatArgs = @{
+            LogicalId     = 'ssmesourcedatasync'
+            SyncName      = $StackName
+            S3Destination = $S3Destination
+            Bucketregion  = $BucketRegion
+            SyncType      = 'SyncToDestination'
+
+        }
+        $template.AddResource(
+            (New-VSSSMResourceDataSync @SplatArgs)
+        )
+        Export-Vaporshell -Path $ExportTemplate -VaporshellTemplate $template -Force -ValidateTemplate -As YAML
+        vsl -action vaporize --tf $ExportTemplate --sn $StackName --caps iam --v --f --w
+        Watch-Stack $stackName
+    }
+}

--- a/Examples/SSM Resource Datasync - Multiple Accounts.ps1
+++ b/Examples/SSM Resource Datasync - Multiple Accounts.ps1
@@ -2,7 +2,7 @@ Import-Module Nameit, Vaporshell
 $BuildRoot = $PSScriptRoot
 
 # Assume this was created in a different step
-$S3Destination = 'Foobar'
+$BucketName = 'Foobar'
 $BucketRegion = 'eu-west-1'
 $ExportPath =  Join-Path $BuildRoot 'cloudformation'
 New-Item -Path $ExportPath -ItemType Directory -Force | Out-Null
@@ -32,10 +32,12 @@ foreach ($AWSProfileName in $AWSProfilesList)
         $SplatArgs = @{
             LogicalId     = 'ssmesourcedatasync'
             SyncName      = $StackName
-            S3Destination = $S3Destination
-            Bucketregion  = $BucketRegion
+            S3Destination = @{
+                BucketRegion = $BucketRegion
+                BucketName   = $BucketName
+                SyncFormat   = 'JsonSerDe'
+            }
             SyncType      = 'SyncToDestination'
-
         }
         $template.AddResource(
             (New-VSSSMResourceDataSync @SplatArgs)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,6 +12,9 @@ trigger:
   branches:
     include:
     - refs/heads/*
+  paths:
+    exclude:
+    - Examples
 
 schedules:
   - cron: "0 16 * * 4"


### PR DESCRIPTION
Trying to configure a multi-region aws ssm resource datasync.

Comparing terraform to vaporshell in the execution as I've had some issues with creating in Terraform and want to see if it's related to the Terraform AWS provider or something else I'm doing wrong.

I figured rather than isolating this in a slack chat conversation, I'd put this in your examples repo, as examples are so important to getting folks up and running quickly :-)

Primary things to ask in my absolutely elegant and stunning code is: 

1. Is there a better way to iterate through regions/accounts using organizations that I'm not aware of?
2. Stack naming make sense? 
3. I get error when running the resource datasync that I'm digging telling me 


```log
VERBOSE: Parsing parameters
VERBOSE: Parsed parameters:

Name         Value
----         -----
Verbose      True
Watch        True
Force        True
TemplateFile ..../datasync-eu-w…
S3Bucket     not-gonna-post-public-im-to-devopsy-for-that
StackName    ssm-resource-data-sync-eu-west-1
Capabilities CAPABILITY_IAM


VERBOSE: Invoking action: vaporize
VERBOSE: Checking if bucket 'not-gonna-post-public-im-to-devopsy-for-that' exists
VERBOSE: Creating new bucket 'not-gonna-post-public-im-to-devopsy-for-that' <----- NOTE... it shouldn't even try to do that?
VERBOSE: Creating change set as UPDATE
vsl: Template format error: unsupported structure.

```


The cloudformation it generates is

```cloudformation
Description: Resource datasync for SSM
Resources:
  ssmesourcedatasync:
    Type: AWS::SSM::ResourceDataSync
    Properties:
      BucketRegion: eu-west-1
      SyncName: ssm-resource-data-sync-eu-west-1
      S3Destination: not-gonna-post-public-im-to-devopsy-for-that
      SyncType: SyncToDestination
```

but it errors with that `vsl: Template format error: unsupported structure.`.
Please note... I'm a terraform user, so if I'm incorrectly composing the actual cloudformation doc and this is only one piece... I'm sorry for that... :grin:


EDIT: The error message when I tried to upload this directly in cloudformation was more insightful (not sure how to get this error detail output from vaporshell to avoid this need). 

```log
Property validation failure: [Value of property {/S3Destination} does not match type {Object}]
```


